### PR TITLE
Added initial alt engine support (Mots, SWDW, etc). Added proper loading directories for DroidWorks. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test_log.txt
 tempdir/
 *.swp
 *.pyc
+**~

--- a/src/base/content/content_manager.cpp
+++ b/src/base/content/content_manager.cpp
@@ -3,6 +3,7 @@
 #include "base/diagnostics/helper.h"
 #include "base/io/exception.h"
 #include <boost/format.hpp>
+using namespace std;
 
 gorc::content::content_manager::content_manager(diagnostics::report& report, const io::file_system& fs)
     : report(report), fs(fs) {
@@ -18,6 +19,7 @@ std::tuple<int, gorc::content::asset*> gorc::content::content_manager::internal_
         try {
             target_path = root / name;
             file = fs.open(target_path);
+
             break;
         }
         catch(...) {

--- a/src/base/content/loaders/sound_loader.cpp
+++ b/src/base/content/loaders/sound_loader.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include <cstdint>
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::sound_loader::asset_root_path = { "sound", "voice" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::sound_loader::asset_root_path = { "sound", "voice", "mission/sound", "" };
 
 std::unique_ptr<gorc::content::asset> gorc::content::loaders::sound_loader::deserialize(const boost::filesystem::path&,
         io::read_only_file& file, content_manager&, diagnostics::report&) {

--- a/src/base/engine.cpp
+++ b/src/base/engine.cpp
@@ -1,0 +1,3 @@
+#include "engine.h"
+
+std::string gorc::engine::enginename = "JEDI";

--- a/src/base/engine.h
+++ b/src/base/engine.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "base/place/presenter.h"
+#include "base/utility/time.h"
+
+namespace gorc {
+
+class engine {
+public:
+    static std::string enginename;
+
+    static std::string getEngine() { 
+        return enginename;
+    }
+};
+
+}

--- a/src/client/application.cpp
+++ b/src/client/application.cpp
@@ -5,11 +5,13 @@
 #include "world/level_view.h"
 #include <boost/algorithm/string/predicate.hpp>
 #include "base/events/print.h"
+#include "base/engine.h"
 
 gorc::client::application::application(content::vfs::virtual_file_system& vfs, diagnostics::report& report,
-        const std::string& episode_name, const std::string& level_name)
+        const std::string& episode_name, const std::string& level_name, std::string& engine_name)
     : gorc::application<view_layer, presenter, presenter_mapper>("Gorc", mapper, report, vfs, make_box(make_vector(0, 0), make_vector(1280, 720)), true),
       mapper(*this), input_episodename(episode_name), input_levelname(level_name), virtual_filesystem(vfs) {
+    gorc::engine::enginename = engine_name;
     return;
 }
 
@@ -23,7 +25,7 @@ void gorc::client::application::startup(event_bus& eventbus, content::content_ma
         std::cout << print.message << std::endl;
     });
 
-    hud_view = make_unique<class hud_view>(content);
+    hud_view = make_unique<class hud_view>(content, gorc::engine::enginename);
     level_view = make_unique<world::level_view>(content);
     action_view = make_unique<action::action_view>();
 

--- a/src/client/application.h
+++ b/src/client/application.h
@@ -44,7 +44,7 @@ public:
     game::level_state components;
 
     application(content::vfs::virtual_file_system& filesystem, diagnostics::report& report,
-            const std::string& input_episodename, const std::string& input_levelname);
+            const std::string& input_episodename, const std::string& input_levelname, std::string& input_enginename);
     ~application();
 
     virtual void startup(event_bus& eventbus, content::content_manager& content) override;

--- a/src/client/hud_view.cpp
+++ b/src/client/hud_view.cpp
@@ -6,23 +6,26 @@
 #include "base/gui/widgets/static_image.h"
 #include "base/gui/widgets/static_text.h"
 
-gorc::client::hud_view::hud_view(content::content_manager& manager)
+gorc::client::hud_view::hud_view(content::content_manager& manager, std::string enginename)
     : gui_view(manager.load<content::assets::shader>("gui.glsl")) {
-    auto& dfltcmp = manager.load<content::assets::colormap>("dflt.cmp");
-    const auto& statusleft = manager.load<content::assets::bitmap>("statusleft16.bm", dfltcmp);
-    const auto& statusright = manager.load<content::assets::bitmap>("statusright16.bm", dfltcmp);
 
-    auto& left = add_child<gui::widgets::static_image>(get_root(), statusleft.cels[0].color, make_box(make_vector(0, 0), make_vector(59, 60)));
-    left.horizontal_align = gui::layout::horizontal_align_style::left;
-    left.vertical_align = gui::layout::vertical_align_style::bottom;
+    if(enginename == "JEDI") {
+        auto& dfltcmp = manager.load<content::assets::colormap>("dflt.cmp");
+        const auto& statusleft = manager.load<content::assets::bitmap>("statusleft16.bm", dfltcmp);
+        const auto& statusright = manager.load<content::assets::bitmap>("statusright16.bm", dfltcmp);
 
-    auto& right = add_child<gui::widgets::static_image>(get_root(), statusright.cels[0].color, make_box(make_vector(0, 0), make_vector(59, 60)));
-    right.horizontal_align = gui::layout::horizontal_align_style::right;
-    right.vertical_align = gui::layout::vertical_align_style::bottom;
+        auto& left = add_child<gui::widgets::static_image>(get_root(), statusleft.cels[0].color, make_box(make_vector(0, 0), make_vector(59, 60)));
+        left.horizontal_align = gui::layout::horizontal_align_style::left;
+        left.vertical_align = gui::layout::vertical_align_style::bottom;
 
-    auto& msgfont = manager.load<content::assets::sfont>("msgfont16.sft", dfltcmp);
+        auto& right = add_child<gui::widgets::static_image>(get_root(), statusright.cels[0].color, make_box(make_vector(0, 0), make_vector(59, 60)));
+        right.horizontal_align = gui::layout::horizontal_align_style::right;
+        right.vertical_align = gui::layout::vertical_align_style::bottom;
 
-    auto& message_label = add_child<gui::widgets::static_text>(get_root(), msgfont, "GORC TEST");
-    message_label.horizontal_align = gui::layout::horizontal_align_style::center;
-    message_label.vertical_align = gui::layout::vertical_align_style::top;
+        auto& msgfont = manager.load<content::assets::sfont>("msgfont16.sft", dfltcmp);
+
+        auto& message_label = add_child<gui::widgets::static_text>(get_root(), msgfont, "GORC TEST");
+        message_label.horizontal_align = gui::layout::horizontal_align_style::center;
+        message_label.vertical_align = gui::layout::vertical_align_style::top;
+    }
 }

--- a/src/client/hud_view.h
+++ b/src/client/hud_view.h
@@ -8,7 +8,7 @@ namespace client {
 
 class hud_view : public gorc::gui::gui_view {
 public:
-    hud_view(content::content_manager& manager);
+    hud_view(content::content_manager& manager, std::string enginename);
 };
 
 }

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -5,9 +5,15 @@
 #include "content/vfs/virtual_file_system.h"
 
 int main(int argc, char** argv) {
-    if(argc != 3) {
-        std::cout << "Usage: game \"Episode Name\" levelfilename.jkl" << std::endl;
+    if(argc < 3 || argc > 4) {
+        std::cout << "Usage: game \"Episode Name\" levelfilename.jkl {Engine Type}" << std::endl;
         return 0;
+    }
+
+    std::string engine_name = "JEDI";
+    if(argc > 3)
+    {
+        engine_name = argv[3];
     }
 
     std::string episode_name = argv[1];
@@ -15,7 +21,7 @@ int main(int argc, char** argv) {
 
     gorc::diagnostics::stream_report report(std::cout);
     gorc::content::vfs::virtual_file_system fs("game/restricted", "game/resource", "game/episode", report);
-    gorc::client::application app(fs, report, episode_name, levelfile_name);
+    gorc::client::application app(fs, report, episode_name, levelfile_name, engine_name);
     app.run();
     return 0;
 }

--- a/src/content/loaders/animation_loader.cpp
+++ b/src/content/loaders/animation_loader.cpp
@@ -8,7 +8,7 @@
 #include <tuple>
 #include <vector>
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::animation_loader::asset_root_path = { "3do/key" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::animation_loader::asset_root_path = { "3do/key", "mission/key" };
 
 namespace gorc {
 namespace content {

--- a/src/content/loaders/colormap_loader.cpp
+++ b/src/content/loaders/colormap_loader.cpp
@@ -4,7 +4,7 @@
 #include "base/io/exception.h"
 #include "base/io/binary_input_stream.h"
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::colormap_loader::asset_root_path = { "misc/cmp" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::colormap_loader::asset_root_path = { "misc/cmp", "misc" };
 
 std::unique_ptr<gorc::content::asset> gorc::content::loaders::colormap_loader::deserialize(const boost::filesystem::path& filename,
         io::read_only_file& file, content_manager&, diagnostics::report& report) {

--- a/src/content/loaders/inventory_loader.cpp
+++ b/src/content/loaders/inventory_loader.cpp
@@ -2,9 +2,11 @@
 #include "content/assets/inventory.h"
 #include "base/diagnostics/helper.h"
 #include "base/io/exception.h"
+#include "base/engine.h"
+#include "client/application.h"
 #include <boost/format.hpp>
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::inventory_loader::asset_root_path = { "misc" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::inventory_loader::asset_root_path = { "misc", "mission" };
 
 gorc::content::loaders::inventory_loader::inventory_loader(cog::compiler& compiler) : compiler(compiler) {
     return;
@@ -13,6 +15,9 @@ gorc::content::loaders::inventory_loader::inventory_loader(cog::compiler& compil
 std::unique_ptr<gorc::content::asset> gorc::content::loaders::inventory_loader::parse(text::tokenizer& t,
         content::content_manager& manager, diagnostics::report& report) {
     std::unique_ptr<content::assets::inventory> dat(new content::assets::inventory());
+
+    if(gorc::engine::enginename != "JEDI") //TODO: Droidworks and MoTS inventory handling
+        return std::unique_ptr<asset>(std::move(dat));
 
     text::token tok;
     while(true) {

--- a/src/content/loaders/level_loader.cpp
+++ b/src/content/loaders/level_loader.cpp
@@ -10,7 +10,7 @@
 #include <tuple>
 #include <vector>
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::level_loader::asset_root_path = { "jkl" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::level_loader::asset_root_path = { "jkl", "mission" };
 
 namespace gorc {
 namespace content {

--- a/src/content/loaders/material_loader.cpp
+++ b/src/content/loaders/material_loader.cpp
@@ -6,7 +6,7 @@
 #include <array>
 #include <boost/format.hpp>
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::material_loader::asset_root_path = { "mat", "3do/mat" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::material_loader::asset_root_path = { "mat", "3do/mat", "mission/3do/mat", "mission/mat"};
 
 namespace gorc {
 namespace content {

--- a/src/content/loaders/model_loader.cpp
+++ b/src/content/loaders/model_loader.cpp
@@ -9,7 +9,7 @@
 #include <vector>
 #include "content/constants.h"
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::model_loader::asset_root_path = { "3do" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::model_loader::asset_root_path = { "3do", "mission/3do" };
 
 namespace gorc {
 namespace content {

--- a/src/content/loaders/puppet_loader.cpp
+++ b/src/content/loaders/puppet_loader.cpp
@@ -8,7 +8,7 @@
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::puppet_loader::asset_root_path = { "misc/pup" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::puppet_loader::asset_root_path = { "misc/pup", "mission/pup" };
 
 namespace gorc {
 namespace content {

--- a/src/content/loaders/script_loader.cpp
+++ b/src/content/loaders/script_loader.cpp
@@ -1,7 +1,7 @@
 #include "script_loader.h"
 #include "content/assets/script.h"
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::script_loader::asset_root_path = { "cog" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::script_loader::asset_root_path = { "cog", "mission/cog" };
 
 gorc::content::loaders::script_loader::script_loader(const cog::compiler& compiler)
     : compiler(compiler) {

--- a/src/content/loaders/sprite_loader.cpp
+++ b/src/content/loaders/sprite_loader.cpp
@@ -5,7 +5,7 @@
 #include "base/content/content_manager.h"
 #include <boost/format.hpp>
 
-const std::vector<boost::filesystem::path> gorc::content::loaders::sprite_loader::asset_root_path = { "misc/spr" };
+const std::vector<boost::filesystem::path> gorc::content::loaders::sprite_loader::asset_root_path = { "misc/spr", "mission/spr" };
 
 gorc::content::loaders::sprite_loader::sprite_loader(const content::assets::colormap& colormap) : colormap(colormap) {
     return;

--- a/src/game/world/level_presenter.cpp
+++ b/src/game/world/level_presenter.cpp
@@ -4,6 +4,7 @@
 #include "physics/query.h"
 #include "base/events/print.h"
 #include "base/events/exit.h"
+#include "base/engine.h"
 #include "game/level_state.h"
 #include "game/world/physics/physics_presenter.h"
 #include "game/world/animations/animation_presenter.h"
@@ -56,8 +57,12 @@ gorc::game::world::level_presenter::~level_presenter() {
 
 void gorc::game::world::level_presenter::start(event_bus& eventBus) {
     eventbus = &eventBus;
-    model = make_unique<level_model>(eventBus, *place.contentmanager, components.compiler, place.level,
-            place.contentmanager->load<content::assets::inventory>("items.dat", components.compiler));
+            if(gorc::engine::enginename == "JEDI") {
+                model = make_unique<level_model>(eventBus, *place.contentmanager, components.compiler, place.level, place.contentmanager->load<content::assets::inventory>("items.dat", components.compiler));
+            }
+            else if(gorc::engine::enginename == "SWDW") {
+                model = make_unique<level_model>(eventBus, *place.contentmanager, components.compiler, place.level, place.contentmanager->load<content::assets::inventory>("items.inv", components.compiler));
+            }
 
     // Create local aspects
     model->ecs.emplace_aspect<aspects::thing_controller_aspect>(*this);


### PR DESCRIPTION
At the moment it's very buggy and inventory loading is nulled out for any game other than JK:DF2. For the most part though it seems that the issues with porting gorc to work with alternate engines like the ones used in Star Wars: DroidWorks is the addition of more verbs in the gorc compiler, changes in loading (ie inventories swap a few things around) and other things. For the most part it seems that DroidWorks is very similar to DF2 in structure, but has a few differences in loading directories and a few more things in regards to how models are loaded due to the drag-n-drop nature of the robot building (ie arms, legs, and all other models are completely separate, even for NPCs).

So far the only maps that are working are moisture.jkl, factory.jkl, and deployment.jkl. All other maps crash due to unknown reasons. It should also be noted that the game defaults the character as a storage box since, under normal conditions, you build your droids, so the model parsing is overridden by the engine.

Aside from the additions to allow the loading of DroidWorks data, no regressions in terms of DF2 loading were made and the diffs are somewhat clean. HUD rendering still needs to be done and is nulled out for DroidWorks only. Criticism on the alt-engine checking is welcome. :)
