### PR TITLE
Prevent loading of nonexistant animations. Default to idling animation if existant.

### DIFF
--- a/src/content/assets/puppet_mode.h
+++ b/src/content/assets/puppet_mode.h
@@ -11,10 +11,18 @@ namespace assets {
 
 class puppet_mode {
 public:
-    std::array<puppet_submode, 64> submodes;
+    std::unordered_map<int, puppet_submode> submodes;
 
     inline const puppet_submode& get_submode(flags::puppet_submode_type type) const {
-        return submodes[static_cast<unsigned int>(type)];
+        if(submodes.find(static_cast<unsigned int>(type)) == submodes.end())
+            return submodes.at(0); //Return idle by default if submode is nonexistant
+        return submodes.at(static_cast<unsigned int>(type));
+    }
+
+    inline const int submode_exists(flags::puppet_submode_type type) const {
+        if(submodes.find(static_cast<unsigned int>(type)) == submodes.end() || submodes.find(0) == submodes.end())
+            return 0;
+        return 1;
     }
 };
 

--- a/src/game/world/aspects/puppet_animation_aspect.cpp
+++ b/src/game/world/aspects/puppet_animation_aspect.cpp
@@ -99,8 +99,8 @@ void puppet_animation_aspect::set_walk_animation(components::thing &thing,
                                                  components::puppet_animations &pup,
                                                  flags::puppet_submode_type type,
                                                  float speed) {
-    if(thing.type == flags::thing_type::Corpse || pup.actor_walk_animation < 0) {
-        // Thing is dead and cannot play a walk animation.
+    if(thing.type == flags::thing_type::Corpse || pup.actor_walk_animation < 0 || pup.puppet.get_mode(pup.puppet_mode_type).submode_exists(type) == 0) {
+        // Thing is dead and/or cannot play a walk animation.
         return;
     }
 

--- a/src/game/world/keys/key_presenter.cpp
+++ b/src/game/world/keys/key_presenter.cpp
@@ -297,7 +297,8 @@ int gorc::game::world::keys::key_presenter::play_mode(entity_id thing_id,
 
     content::assets::puppet_submode const *submode_ptr = nullptr;
     for(auto const &tpup : levelModel->ecs.find_component<components::puppet_animations>(thing_id)) {
-        submode_ptr = &tpup.second.puppet.get_mode(tpup.second.puppet_mode_type).get_submode(minor_mode);
+        if(tpup.second.puppet.get_mode(tpup.second.puppet_mode_type).submode_exists(minor_mode))
+            submode_ptr = &tpup.second.puppet.get_mode(tpup.second.puppet_mode_type).get_submode(minor_mode);
     }
 
     if(!submode_ptr) {

--- a/src/game/world/level_presenter.cpp
+++ b/src/game/world/level_presenter.cpp
@@ -1006,6 +1006,7 @@ gorc::flags::puppet_mode_type gorc::game::world::level_presenter::get_major_mode
 }
 
 void gorc::game::world::level_presenter::register_verbs(cog::verbs::verb_table& verbTable, level_state& components) {
+
     camera::camera_presenter::register_verbs(verbTable, components);
     animations::animation_presenter::register_verbs(verbTable, components);
     scripts::script_presenter::register_verbs(verbTable, components);
@@ -1291,6 +1292,7 @@ void gorc::game::world::level_presenter::register_verbs(cog::verbs::verb_table& 
         components.current_level_presenter->attach_thing_to_thing(attach_thing, base_thing);
     });
 
+    //TODO: Fix SWDW implementation
     verbTable.add_verb<int, 2>("creatething", [&components](int tpl_id, int thing_pos) {
         return components.current_level_presenter->create_thing_at_thing(tpl_id, thing_pos);
     });
@@ -1346,6 +1348,7 @@ void gorc::game::world::level_presenter::register_verbs(cog::verbs::verb_table& 
         return static_cast<int>(components.current_level_presenter->get_actor_flags(thing_id));
     });
 
+    //TODO: Fix SWDW implementation
     verbTable.add_verb<void, 2>("setactorflags", [&components](int thing_id, int flags) {
         components.current_level_presenter->set_actor_flags(thing_id, flag_set<flags::actor_flag>(flags));
     });
@@ -1399,6 +1402,7 @@ void gorc::game::world::level_presenter::register_verbs(cog::verbs::verb_table& 
         return static_cast<int>(components.current_level_presenter->get_thing_type(thing_id));
     });
 
+    //TODO: Fix SWDW implementation
     verbTable.add_verb<void, 3>("setthinglight", [&components](int thing_id, float light, float fade_time) {
         components.current_level_presenter->set_thing_light(thing_id, light, fade_time);
     });


### PR DESCRIPTION
Fixes a few issues with DroidWorks models, specifically an odd quirk (possibly due to the nature of the resources themselves since maps are generally very sloped which seems to play odd with the physics engine) which caused NPCs to jump at the game's start. Since most of the NPC's jump, crouch, turnleft and turnright behaviors were undefined, they would load a nonexistant animation and their parts would compress into a large 'blob'. This fix may or may not be a retroactive fix into DF2, although I have yet to see any issues that were similar to the ones with DroidWorks.

EDIT: This issue _is_ present in DF2, and can be reproduced by pushing a rodian off the ledge in 01narshadda.jkl. Due to the lack of a falling animation it will kinda scrunch up and not load any new animations anymore.

EDIT 2: So apparently this also seems to happen when mn.3do (skinny commoner dude) is on a slope, which probably explains the issues in DroidWorks since that game is very heavy on slopes. I also managed to grab a screenshot of the issue I fixed which can be found [here](http://i.imgur.com/Ftysrkn.png).
