### PR TITLE
Adjusted listening direction so that the yaw is a proper value between 0 and 1. 

### DIFF
--- a/src/game/world/sounds/sound_presenter.cpp
+++ b/src/game/world/sounds/sound_presenter.cpp
@@ -36,7 +36,7 @@ void sound_presenter::update(const time& time) {
     const auto& cam = levelModel->camera_model.current_computed_state;
     auto camera_position = cam.position;
     auto listener_target = cam.look;
-    sf::Listener::setDirection(get<0>(listener_target), get<2>(listener_target), -get<1>(listener_target));
+    sf::Listener::setDirection(get<0>(listener_target), get<2>(listener_target), (1 - get<1>(listener_target)) / 2);
     sf::Listener::setPosition(get<0>(camera_position), get<2>(camera_position), -get<1>(camera_position));
     // TODO: Handle camera orientation (not properly implemented in SFML).
     const auto& player_sec = levelModel->sectors[cam.containing_sector];


### PR DESCRIPTION
X and Y values still need proper adjustment. It might be better to not use SFML's sound system and opt for another sound engine, but for now at least the sounds will sound somewhat proper. Remaining issues include the issue where if the pitch orientation is too low sounds will be very quiet instead of much louder like they should be and sounds fading too suddenly when moving.
