### PR TITLE
Add include to fix compilation with gcc 10.2

### DIFF
--- a/src/jk/vfs/episode_entry_type.cpp
+++ b/src/jk/vfs/episode_entry_type.cpp
@@ -1,6 +1,7 @@
 #include "episode_entry_type.hpp"
 #include "utility/enum_hash.hpp"
 #include <unordered_map>
+#include <stdexcept>
 
 using namespace gorc;
 


### PR DESCRIPTION
Fixes #11 

Had the same issue as @darkstar252.
`std::range_error` is defined `stdexcept` header: https://en.cppreference.com/w/cpp/error/range_error

With this fix it compiles and runs for me on Manjaro.